### PR TITLE
Allow failures of Linux Musl builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
     - PATH="$HOME/.cargo/bin:$PATH"
 
 matrix:
+  allow_failures:
+    - env: TARGET=x86_64-unknown-linux-musl
+
   include:
     - os: linux
       rust: stable
@@ -19,9 +22,9 @@ matrix:
     - os: linux
       rust: beta
       env: TARGET=x86_64-unknown-linux-gnu
-    #- os: linux
-    #  rust: beta
-    #  env: TARGET=x86_64-unknown-linux-musl
+    - os: linux
+      rust: beta
+      env: TARGET=x86_64-unknown-linux-musl
     - os: osx
       rust: beta
       env: TARGET=x86_64-apple-darwin
@@ -29,9 +32,9 @@ matrix:
     - os: linux
       rust: nightly
       env: TARGET=x86_64-unknown-linux-gnu
-    #- os: linux
-    #  rust: nightly
-    #  env: TARGET=x86_64-unknown-linux-musl
+    - os: linux
+      rust: nightly
+      env: TARGET=x86_64-unknown-linux-musl
     - os: osx
       rust: nightly
       env: TARGET=x86_64-apple-darwin

--- a/ci/travis_setup.sh
+++ b/ci/travis_setup.sh
@@ -11,10 +11,7 @@ install_rustup() {
 
 
 install_target() {
-    local default_target=`rustup target list | grep '(default)' | cut -d ' ' -f 1`
-    if [[ "${default_target}" != "${TARGET}" ]]; then
-        rustup target add $TARGET
-    fi
+    rustup target add $TARGET || true
 }
 
 


### PR DESCRIPTION
ld failures (in stable now) preventing musl builds from working. While
we aren't actually building release binaries from Travis results, just
ignore the failures.
