### PR TITLE
Don't reference binary name in help output

### DIFF
--- a/src/bin/st.rs
+++ b/src/bin/st.rs
@@ -165,7 +165,7 @@ fn main() {
         // expecting them to display help.
         eprintln!(concat!(
             "notice: waiting for input from stdin. If this isn't what you ",
-            "want, try `st --help`"
+            "want, try running with the `--help` option"
         ));
 
         get_values(&mut BufReader::new(stdin()), sorting)


### PR DESCRIPTION
Fixes #15